### PR TITLE
feat: 구글 지도

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,8 +1,15 @@
 import React from "react";
 import Router from "./src/navigation/router";
 
+import { Provider } from "react-redux";
+import store from "./src/store/config/config";
+
 const App = () => {
-  return <Router />;
+  return (
+    <Provider store={store}>
+      <Router />
+    </Provider>
+  );
 };
 
 export default App;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
   package="com.walkingtravel">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
       android:name=".MainApplication"
@@ -22,5 +24,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+      <meta-data
+        android:name="com.google.android.geo.API_KEY"
+        android:value="@string/GOOGLE_API_KEY"
+      />
     </application>
 </manifest>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,6 +1830,17 @@
         "nanoid": "^3.1.23"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
+      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -1913,12 +1924,26 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
       "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -1959,11 +1984,36 @@
       "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/react": {
+      "version": "18.0.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.14.tgz",
+      "integrity": "sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/yargs": {
       "version": "17.0.10",
@@ -3001,6 +3051,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
     "dayjs": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
@@ -3109,6 +3164,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "requires": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
+      }
     },
     "destroy": {
       "version": "1.2.0",
@@ -4306,6 +4371,21 @@
         }
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4345,6 +4425,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
       "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+    },
+    "immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -6961,7 +7046,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6971,8 +7055,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -7171,10 +7254,24 @@
       "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.4.6.tgz",
       "integrity": "sha512-cSLdOfva2IPCxh6HjHN1IDVW9ratAvNnnAUx6ar2Byvr8KQU7++ysdFYPaoNVuJURuYoAKgvjab8ZcnwGZIO6Q=="
     },
+    "react-native-geolocation-service": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-geolocation-service/-/react-native-geolocation-service-5.3.0.tgz",
+      "integrity": "sha512-imK/yjxqPMIydSjZLpqPh7U073Fpe1JAaZHiIzLzWnzv89OGey6t4Zj/POg3+xtmGcbDoMcEOx8hbNY/fXaD9Q=="
+    },
     "react-native-gradle-plugin": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
+    },
+    "react-native-maps": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.31.1.tgz",
+      "integrity": "sha512-vipeOPykqLRMCLcLUCZEB+cTdNSlq88NLb0jChY4UGTY5fgOS7GYWkfswy6bW1ayTRLxJS3zpMGFDUY59/ZrXA==",
+      "requires": {
+        "@types/geojson": "^7946.0.7",
+        "deprecated-react-native-prop-types": "^2.3.0"
+      }
     },
     "react-native-safe-area-context": {
       "version": "4.3.1",
@@ -7188,6 +7285,26 @@
       "requires": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      }
+    },
+    "react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
       }
     },
     "react-refresh": {
@@ -7253,6 +7370,19 @@
         "source-map": "~0.6.1",
         "tslib": "^2.0.1"
       }
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -7350,6 +7480,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,16 @@
     "@react-native-google-signin/google-signin": "^8.0.0",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
+    "@reduxjs/toolkit": "^1.8.3",
     "axios": "^0.27.2",
     "react": "18.0.0",
     "react-native": "0.69.1",
     "react-native-config": "^1.4.6",
+    "react-native-geolocation-service": "^5.3.0",
+    "react-native-maps": "^0.31.1",
     "react-native-safe-area-context": "^4.3.1",
-    "react-native-screens": "^3.14.0"
+    "react-native-screens": "^3.14.0",
+    "react-redux": "^8.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/src/api/GeoLocationAPI.js
+++ b/src/api/GeoLocationAPI.js
@@ -1,0 +1,73 @@
+import GeoLocation from "react-native-geolocation-service";
+import { PermissionsAndroid } from "react-native";
+
+import { updateRegion } from "../store/slices/regionSlice";
+
+export default function GeoLocationAPI(dispatch) {
+  const getCurrentLocation = () => {
+    let currentPosition = null;
+
+    GeoLocation.getCurrentPosition(
+      position => {
+        currentPosition = position;
+
+        dispatch(
+          updateRegion({
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            latitudeDelta: 0.015,
+            longitudeDelta: 0.0121,
+          })
+        );
+      },
+      error => {
+        if (error.code === 1) {
+          requestLocationPermission();
+        }
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 10000 }
+    );
+
+    return GeoLocation.watchPosition(
+      position => {
+        if (currentPosition.coords.latitude !== position.coords.latitude) {
+          dispatch(
+            updateRegion({
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+              latitudeDelta: 0.015,
+              longitudeDelta: 0.0121,
+            })
+          );
+        }
+      },
+      error => {
+        if (error.code === 1) {
+          requestLocationPermission();
+        }
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 10000, distanceFilter: 30 }
+    );
+  };
+
+  const requestLocationPermission = async () => {
+    try {
+      const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION, {
+        title: "Get MyLocation Permission",
+        message: "Needs to access your current location",
+        buttonNegative: "Cancel",
+        buttonPositive: "OK",
+      });
+
+      if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+        getCurrentLocation();
+      } else {
+        console.log("Location permission denied");
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return getCurrentLocation();
+}

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -1,0 +1,30 @@
+import React, { useEffect } from "react";
+import { StyleSheet, Dimensions } from "react-native";
+
+import MapView from "react-native-maps";
+import GeoLocation from "react-native-geolocation-service";
+import GeoLocationAPI from "../api/GeoLocationAPI";
+
+import { useDispatch, useSelector } from "react-redux";
+
+export default function GoogleMap() {
+  const dispatch = useDispatch();
+  const region = useSelector(state => state.region.region);
+
+  useEffect(() => {
+    const watchId = GeoLocationAPI(dispatch);
+
+    return () => {
+      GeoLocation.clearWatch(watchId);
+    };
+  }, []);
+
+  return <MapView style={styles.map} region={region} showsUserLocation={true} showsMyLocationButton={true}></MapView>;
+}
+
+const styles = StyleSheet.create({
+  map: {
+    width: Dimensions.get("screen").width * 1,
+    height: Dimensions.get("screen").height * 1,
+  },
+});

--- a/src/screens/Login/index.js
+++ b/src/screens/Login/index.js
@@ -11,7 +11,9 @@ export default function LoginScreen({ navigation }) {
   useEffect(() => {
     googleSiginConfigure();
 
-    auth().onAuthStateChanged(onAuthStateChanged);
+    if (!checkIsLoggedIn()) {
+      auth().onAuthStateChanged(onAuthStateChanged);
+    }
   }, []);
 
   const googleSiginConfigure = () => {
@@ -34,6 +36,15 @@ export default function LoginScreen({ navigation }) {
         navigation.navigate("Main");
       }
     }
+  };
+
+  const checkIsLoggedIn = () => {
+    if (auth().currentUser) {
+      navigation.navigate("Main");
+      return true;
+    }
+
+    return false;
   };
 
   const handleGoogleLoginButtonPress = async () => {

--- a/src/screens/Main/index.js
+++ b/src/screens/Main/index.js
@@ -1,10 +1,12 @@
 import React from "react";
 import { View, Text } from "react-native";
 
+import GoogleMap from "../../components/GoogleMap";
+
 export default function MainScreen() {
   return (
     <View>
-      <Text>메인화면</Text>
+      <GoogleMap />
     </View>
   );
 }

--- a/src/store/config/config.js
+++ b/src/store/config/config.js
@@ -1,0 +1,12 @@
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import region from "../slices/regionSlice";
+
+const rootReducer = combineReducers({
+  region,
+});
+
+const store = configureStore({
+  reducer: rootReducer,
+});
+
+export default store;

--- a/src/store/slices/regionSlice.js
+++ b/src/store/slices/regionSlice.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  region: {
+    latitude: 37.497,
+    longitude: 127.0254,
+    latitudeDelta: 0.015,
+    longitudeDelta: 0.0121,
+  },
+};
+
+const regionSlice = createSlice({
+  name: "region",
+  initialState,
+  reducers: {
+    updateRegion(state, action) {
+      state.region = action.payload;
+    },
+  },
+});
+
+export const { updateRegion } = regionSlice.actions;
+
+export default regionSlice.reducer;


### PR DESCRIPTION
- 메인화면에 구글 지도 로드
- 현재 자신의 위치 불러오기
- 현재 자신의 위치 전역상태로 관리하기

## 작업사항
1. 메인화면에 구글 지도를 로드하였습니다.
2. GeoLocation을 통해 현재 위치를 불러온 후에 해당 위치 좌표를 전역상태로 관리하였습니다.
3. 로그인 로직에서 현재 사용자가 로그인을 했는지 체크하는 코드를 추가하였습니다.
4. GeoLocation의 watchPosition 메소드를 사용하여 유저의 위치 변동을 추적할 수 있습니다.

## 이슈
1. 앱이 실행되고 맨 처음 위치를 불러올 때는 getCurrentPosition 메소드만 실행되었고 앱을 나갔다가 다시 앱을 실행했을 때 watchPosition 메소드도 같이 실행되어서 불필요한 렌더링이 일어나는 것을 확인하였고 getCurrentPosition에서 불러온 위치값이 watchPosition에서 불러온 위치값과 같지 않을 경우에 대해서만 watchPosition의 위치값을 dispatch 하게끔 하여서 불필요한 dispatch와 렌더링을 방지하였습니다.