### PR TITLE
feat: 선택한 도착 장소로 지도 이동 및 정보 확인

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
+  presets: ["module:metro-react-native-babel-preset"],
+  plugins: ["react-native-reanimated/plugin"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,15 @@
         "@babel/plugin-syntax-export-default-from": "^7.18.6"
       }
     },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.6.tgz",
+      "integrity": "sha512-zr/QcUlUo7GPo6+X1wC98NJADqmy5QTFWWhqeQWiki4XHafJtLl/YMGkmRB2szDD2IYJCCdBTd4ElwhId9T7Xw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
@@ -476,6 +485,14 @@
       "integrity": "sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -716,6 +733,14 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz",
+      "integrity": "sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -934,6 +959,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
@@ -1937,6 +1970,11 @@
         "@types/node": "*"
       }
     },
+    "@types/hammerjs": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1945,6 +1983,11 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
+    },
+    "@types/invariant": {
+      "version": "2.2.35",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
+      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -5703,6 +5746,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7259,6 +7307,18 @@
       "resolved": "https://registry.npmjs.org/react-native-geolocation-service/-/react-native-geolocation-service-5.3.0.tgz",
       "integrity": "sha512-imK/yjxqPMIydSjZLpqPh7U073Fpe1JAaZHiIzLzWnzv89OGey6t4Zj/POg3+xtmGcbDoMcEOx8hbNY/fXaD9Q=="
     },
+    "react-native-gesture-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.5.0.tgz",
+      "integrity": "sha512-djZdcprFf08PZC332D+AeG5wcGeAPhzfCJtB3otUgOgTlvjVXmg/SLFdPJSpzLBqkRAmrC77tM79QgKbuLxkfw==",
+      "requires": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-gradle-plugin": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
@@ -7271,6 +7331,21 @@
       "requires": {
         "@types/geojson": "^7946.0.7",
         "deprecated-react-native-prop-types": "^2.3.0"
+      }
+    },
+    "react-native-reanimated": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.9.1.tgz",
+      "integrity": "sha512-309SIhDBwY4F1n6e5Mr5D1uPZm2ESIcmZsGXHUu8hpKX4oIOlZj2MilTk+kHhi05LjChoJkcpfkstotCJmPRPg==",
+      "requires": {
+        "@babel/plugin-proposal-export-namespace-from": "^7.17.12",
+        "@babel/plugin-transform-object-assign": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "@types/invariant": "^2.2.35",
+        "invariant": "^2.2.4",
+        "lodash.isequal": "^4.5.0",
+        "setimmediate": "^1.0.5",
+        "string-hash-64": "^1.0.3"
       }
     },
     "react-native-safe-area-context": {
@@ -7414,6 +7489,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
+    },
+    "reanimated-bottom-sheet": {
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/reanimated-bottom-sheet/-/reanimated-bottom-sheet-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-NxecCn+2iA4YzkFuRK5/b86GHHS2OhZ9VRgiM4q18AC20YE/psRilqxzXCKBEvkOjP5AaAvY0yfE7EkEFBjTvw=="
     },
     "recast": {
       "version": "0.20.5",
@@ -7734,6 +7814,11 @@
           }
         }
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -8077,6 +8162,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+    },
+    "string-hash-64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
+      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,14 @@
     "react-native": "0.69.1",
     "react-native-config": "^1.4.6",
     "react-native-geolocation-service": "^5.3.0",
+    "react-native-gesture-handler": "^2.5.0",
     "react-native-maps": "^0.31.1",
+    "react-native-reanimated": "^2.9.1",
     "react-native-safe-area-context": "^4.3.1",
     "react-native-screens": "^3.14.0",
     "react-native-vector-icons": "^9.2.0",
-    "react-redux": "^8.0.2"
+    "react-redux": "^8.0.2",
+    "reanimated-bottom-sheet": "^1.0.0-alpha.22"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/src/api/PlaceAutoCompleteAPI.js
+++ b/src/api/PlaceAutoCompleteAPI.js
@@ -1,14 +1,14 @@
 import axios from "axios";
 import Config from "react-native-config";
 
-export default async function PlaceAutoCompleteAPI(text, currentRegion) {
+export default async function PlaceAutoCompleteAPI(text, currentPosition) {
   try {
     const response = await axios.get(
-      `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${text}&language=ko&origin=${currentRegion.latitude}%2C${currentRegion.longitude}&key=${Config.GOOGLE_API_KEY}`
+      `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${text}&language=ko&origin=${currentPosition.latitude}%2C${currentPosition.longitude}&key=${Config.GOOGLE_API_KEY}`
     );
 
     return response.data;
   } catch (error) {
-    console.log(error);
+    console.warn(error);
   }
 }

--- a/src/api/PlaceDetailsAPI.js
+++ b/src/api/PlaceDetailsAPI.js
@@ -16,11 +16,15 @@ export default async function PlaceDetailsAPI(placeId) {
       longitudeDelta: 0.0121,
     };
 
-    const photoURL = `https://maps.googleapis.com/maps/api/place/photo?photo_reference=${response.data.result.photos[0].photo_reference}&key=${Config.GOOGLE_API_KEY}`;
+    let photoURL = null;
+
+    if (response.data.result.photos) {
+      photoURL = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1600&maxWidth=1600&photo_reference=${response.data.result.photos[0].photo_reference}&key=${Config.GOOGLE_API_KEY}`;
+    }
 
     return { message: "success", region, photoURL };
   } catch (error) {
-    console.log(error);
+    console.warn(error);
     return { message: "fail" };
   }
 }

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -6,12 +6,14 @@ import GeoLocation from "react-native-geolocation-service";
 import GeoLocationAPI from "../api/GeoLocationAPI";
 
 import { useDispatch, useSelector } from "react-redux";
+import { updateSheetState } from "../store/slices/sheetSlice";
 
 export default function GoogleMap({ params }) {
   const dispatch = useDispatch();
 
   const currentPosition = useSelector(state => state.user.currentPosition);
   const destination = useSelector(state => state.destination.destination);
+  const isBottomSheetOpen = useSelector(state => state.sheet.isBottomSheetOpen);
 
   useEffect(() => {
     const watchId = GeoLocationAPI(dispatch);
@@ -21,15 +23,29 @@ export default function GoogleMap({ params }) {
     };
   }, []);
 
+  const handlePressMarker = () => {
+    dispatch(updateSheetState());
+  };
+
+  const handlePressMapView = () => {
+    if (isBottomSheetOpen) {
+      dispatch(updateSheetState());
+    }
+  };
+
   return (
     <MapView
-      style={styles.map}
+      style={isBottomSheetOpen ? styles.sheetOpenMap : styles.map}
       region={params ? destination.region : currentPosition}
       showsUserLocation={true}
       showsMyLocationButton={true}
+      onPress={() => handlePressMapView()}
     >
       {destination.photoURL !== "" && (
-        <Marker coordinate={destination.region} />
+        <Marker
+          coordinate={destination.region}
+          onPress={() => handlePressMarker()}
+        />
       )}
     </MapView>
   );
@@ -39,5 +55,11 @@ const styles = StyleSheet.create({
   map: {
     width: Dimensions.get("screen").width * 1,
     height: Dimensions.get("screen").height * 1,
+  },
+  sheetOpenMap: {
+    width: Dimensions.get("screen").width * 1,
+    height: Dimensions.get("screen").height * 1,
+    position: "absolute",
+    bottom: Dimensions.get("screen").height * 0.2,
   },
 });

--- a/src/components/SearchLocationBar.js
+++ b/src/components/SearchLocationBar.js
@@ -1,14 +1,18 @@
 import React from "react";
 import { StyleSheet, Pressable, Text, Dimensions } from "react-native";
 
+import { useSelector } from "react-redux";
+
 export default function SearchLocationBar({ navigation }) {
+  const destination = useSelector(state => state.destination.destination);
+
   const handlePress = () => {
     navigation.navigate("SearchLocation");
   };
 
   return (
     <Pressable style={styles.searchBarContainer} onPress={handlePress}>
-      <Text>Location Search</Text>
+      <Text>{destination.placeName}</Text>
     </Pressable>
   );
 }

--- a/src/components/ViewDestination.js
+++ b/src/components/ViewDestination.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from "react";
+import { View, Text, Image, Dimensions } from "react-native";
+
+import BottomSheet from "reanimated-bottom-sheet";
+import Animated from "react-native-reanimated";
+
+import { useSelector } from "react-redux";
+
+export default function ViewDestination() {
+  const destination = useSelector(state => state.destination.destination);
+  const isBottomSheetOpen = useSelector(state => state.sheet.isBottomSheetOpen);
+
+  const bottomSheefRef = useRef(null);
+
+  useEffect(() => {
+    controlBottomSheet();
+  }, [isBottomSheetOpen]);
+
+  const renderContent = () => {
+    return (
+      <View
+        style={{
+          height: "100%",
+          backgroundColor: "#fff",
+        }}
+      >
+        {destination.photoURL && (
+          <Image
+            source={{ uri: destination.photoURL }}
+            style={{
+              width: "100%",
+              height: "50%",
+            }}
+          />
+        )}
+        <Text>{destination.placeName}</Text>
+        <Text>{destination.distance}</Text>
+      </View>
+    );
+  };
+
+  const controlBottomSheet = () => {
+    if (isBottomSheetOpen) {
+      return bottomSheefRef.current.snapTo(0);
+    }
+
+    bottomSheefRef.current.snapTo(1);
+  };
+
+  return (
+    <BottomSheet
+      ref={bottomSheefRef}
+      renderContent={renderContent}
+      snapPoints={[Dimensions.get("screen").height * 0.6, 0]}
+      borderRadius={10}
+      enabledGestureInteraction={true}
+      enabledContentTapInteraction={false}
+    />
+  );
+}

--- a/src/screens/Main/index.js
+++ b/src/screens/Main/index.js
@@ -1,14 +1,23 @@
 import React from "react";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 
 import GoogleMap from "../../components/GoogleMap";
 import SearchLocationBar from "../../components/SearchLocationBar";
 
+import ViewDestination from "../../components/ViewDestination";
+
 export default function MainScreen({ route, navigation }) {
   return (
-    <View>
+    <View style={styles.container}>
       <GoogleMap params={route.params} />
       <SearchLocationBar navigation={navigation} />
+      <ViewDestination />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/screens/SearchLocation/index.js
+++ b/src/screens/SearchLocation/index.js
@@ -13,6 +13,7 @@ import Ionicons from "react-native-vector-icons/Ionicons";
 
 import { useSelector, useDispatch } from "react-redux";
 import { updateDestination } from "../../store/slices/destinationSlice";
+import { updateSheetState } from "../../store/slices/sheetSlice";
 
 import PlaceAutoCompleteAPI from "../../api/PlaceAutoCompleteAPI";
 import PlaceDetailsAPI from "../../api/PlaceDetailsAPI";
@@ -33,17 +34,18 @@ export default function SearchLocationScreen({ navigation }) {
     setSearchResult(searchResult.predictions);
   };
 
-  const handleSearchListPress = async (placeName, placeId, distance) => {
+  const handlePressSearchList = async (placeName, placeId, distance) => {
     const { message, region, photoURL } = await PlaceDetailsAPI(placeId);
 
     if (message === "success") {
       dispatch(updateDestination({ placeName, region, photoURL, distance }));
+      dispatch(updateSheetState());
 
       navigation.navigate("Main", { selected: true });
     }
   };
 
-  const handleBackButtonPress = () => {
+  const handlePressBackButton = () => {
     navigation.navigate("Main");
   };
 
@@ -56,7 +58,7 @@ export default function SearchLocationScreen({ navigation }) {
       <Pressable
         style={styles.searchListContainer}
         onPress={() =>
-          handleSearchListPress(
+          handlePressSearchList(
             structured_formatting.main_text,
             place_id,
             distance
@@ -81,7 +83,7 @@ export default function SearchLocationScreen({ navigation }) {
   return (
     <View>
       <View style={styles.searchInputContainer}>
-        <Pressable onPress={handleBackButtonPress}>
+        <Pressable onPress={handlePressBackButton}>
           <Ionicons name={"chevron-back-sharp"} size={30} color={"black"} />
         </Pressable>
         <TextInput

--- a/src/store/config/config.js
+++ b/src/store/config/config.js
@@ -1,10 +1,12 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import user from "../slices/userSlice";
 import destination from "../slices/destinationSlice";
+import sheet from "../slices/sheetSlice";
 
 const rootReducer = combineReducers({
   user,
   destination,
+  sheet,
 });
 
 const store = configureStore({

--- a/src/store/slices/destinationSlice.js
+++ b/src/store/slices/destinationSlice.js
@@ -2,14 +2,14 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   destination: {
-    placeName: "",
+    placeName: "Location Search",
     region: {},
     distance: 0,
     photoURL: "",
   },
 };
 
-const regionSlice = createSlice({
+const destinationSlice = createSlice({
   name: "destination",
   initialState,
   reducers: {
@@ -19,6 +19,6 @@ const regionSlice = createSlice({
   },
 });
 
-export const { updateDestination } = regionSlice.actions;
+export const { updateDestination } = destinationSlice.actions;
 
-export default regionSlice.reducer;
+export default destinationSlice.reducer;

--- a/src/store/slices/sheetSlice.js
+++ b/src/store/slices/sheetSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  isBottomSheetOpen: false,
+};
+
+const sheetSlice = createSlice({
+  name: "sheet",
+  initialState,
+  reducers: {
+    updateSheetState(state) {
+      state.isBottomSheetOpen = !state.isBottomSheetOpen;
+    },
+  },
+});
+
+export const { updateSheetState } = sheetSlice.actions;
+
+export default sheetSlice.reducer;


### PR DESCRIPTION
## 작업사항
1. Bottom Sheet 라이브러리 추가하였습니다.
2. 도착 장소 선택 후 메인화면으로 이동 시 바텀 시트가 올라와 해당 장소에 대한 이미지, 장소 이름, 현재 위치로부터의 거리 정보를 표시합니다.
3. 바텀 시트 밖의 지도를 클릭하면 바텀 시트가 내려갑니다.
4. 다시 핑을 클릭하면 바텀 시트가 올라와 해당 장소에 대한 정보를 확인할 수 있습니다.

## 이슈
- 에뮬레이터 환경에서 바텀 시트에 gesture handler가 적용이 안되고 있어서 실제 기기에 연결해서 테스트를 해볼 예정입니다.