### PR TITLE
feat: 도착지까지의 이동경로 표시

### DIFF
--- a/src/api/DirectionsAPI.js
+++ b/src/api/DirectionsAPI.js
@@ -1,0 +1,57 @@
+import axios from "axios";
+import Config from "react-native-config";
+
+export default async function DirectionsAPI(
+  currentRegion,
+  currentPlaceName,
+  destination
+) {
+  try {
+    const response = await axios.post(
+      "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1",
+      {
+        startX: currentRegion.longitude,
+        startY: currentRegion.latitude,
+        endX: destination.region.longitude,
+        endY: destination.region.latitude,
+        startName: currentPlaceName,
+        endName: destination.placeName,
+      },
+      {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          appKey: `${Config.TMAP_APP_KEY}`,
+        },
+      }
+    );
+
+    const points = [];
+    const routes = [];
+
+    const steps = response.data.features;
+    console.log(steps);
+
+    steps.forEach(step => {
+      console.log(step.geometry.coordinates);
+
+      if (step.geometry.type === "Point") {
+        points.push({
+          latitude: step.geometry.coordinates[1],
+          longitude: step.geometry.coordinates[0],
+        });
+      } else {
+        step.geometry.coordinates.forEach(coordinate => {
+          routes.push({
+            latitude: coordinate[1],
+            longitude: coordinate[0],
+          });
+        });
+      }
+    });
+
+    return { points, routes };
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/api/GeoLocationAPI.js
+++ b/src/api/GeoLocationAPI.js
@@ -1,22 +1,32 @@
 import GeoLocation from "react-native-geolocation-service";
 import { PermissionsAndroid } from "react-native";
 
-import { updateCurrentPosition } from "../store/slices/userSlice";
+import GeocodeAPI from "./GeocodeAPI";
+
+import { updateCurrentPoint } from "../store/slices/userSlice";
 
 export default function GeoLocationAPI(dispatch) {
   const getCurrentLocation = () => {
     let currentPosition = null;
 
     GeoLocation.getCurrentPosition(
-      position => {
+      async position => {
         currentPosition = position;
 
+        const placeName = await GeocodeAPI(
+          position.coords.latitude,
+          position.coords.longitude
+        );
+
         dispatch(
-          updateCurrentPosition({
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-            latitudeDelta: 0.015,
-            longitudeDelta: 0.0121,
+          updateCurrentPoint({
+            currentRegion: {
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+              latitudeDelta: 0.015,
+              longitudeDelta: 0.0121,
+            },
+            placeName,
           })
         );
       },
@@ -29,17 +39,25 @@ export default function GeoLocationAPI(dispatch) {
     );
 
     return GeoLocation.watchPosition(
-      position => {
+      async position => {
         if (
           currentPosition &&
           currentPosition.coords.latitude !== position.coords.latitude
         ) {
+          const placeName = await GeocodeAPI(
+            position.coords.latitude,
+            position.coords.longitude
+          );
+
           dispatch(
-            updateCurrentPosition({
-              latitude: position.coords.latitude,
-              longitude: position.coords.longitude,
-              latitudeDelta: 0.015,
-              longitudeDelta: 0.0121,
+            updateCurrentPoint({
+              currentRegion: {
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+                latitudeDelta: 0.015,
+                longitudeDelta: 0.0121,
+              },
+              placeName,
             })
           );
         }

--- a/src/api/GeocodeAPI.js
+++ b/src/api/GeocodeAPI.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+import Config from "react-native-config";
+
+export default async function GeocodeAPI(latitude, longitude) {
+  try {
+    const response = await axios.get(
+      `https://maps.googleapis.com/maps/api/geocode/json?language=ko&latlng=${latitude}%2C${longitude}&key=${Config.GOOGLE_API_KEY}`
+    );
+
+    const placeName = response.data.results[0].formatted_address;
+
+    return placeName;
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { StyleSheet, Dimensions } from "react-native";
 
-import MapView, { Marker } from "react-native-maps";
+import MapView, { Marker, Polyline } from "react-native-maps";
 import GeoLocation from "react-native-geolocation-service";
 import GeoLocationAPI from "../api/GeoLocationAPI";
 
@@ -14,7 +14,7 @@ import {
 } from "react-native-sensors";
 
 import { useDispatch, useSelector } from "react-redux";
-import { updateSheetState } from "../store/slices/sheetSlice";
+import { updateSheetState } from "../store/slices/bottomSheetSlice";
 
 import { LogBox } from "react-native";
 
@@ -24,9 +24,13 @@ export default function GoogleMap({ params }) {
 
   const dispatch = useDispatch();
 
-  const currentPosition = useSelector(state => state.user.currentPosition);
+  const currentRegion = useSelector(state => state.user.currentRegion);
   const destination = useSelector(state => state.destination.destination);
-  const isBottomSheetOpen = useSelector(state => state.sheet.isBottomSheetOpen);
+  const isBottomSheetOpen = useSelector(
+    state => state.bottomSheet.isBottomSheetOpen
+  );
+
+  console.log(destination.points);
 
   useEffect(() => {
     LogBox.ignoreLogs(["new NativeEventEmitter"]);
@@ -67,7 +71,7 @@ export default function GoogleMap({ params }) {
   ) : (
     <MapView
       style={isBottomSheetOpen ? styles.sheetOpenMap : styles.map}
-      region={params || isMarkerPressed ? destination.region : currentPosition}
+      region={params || isMarkerPressed ? destination.region : currentRegion}
       showsUserLocation={true}
       showsMyLocationButton={true}
       onPress={() => handlePressMapView()}
@@ -76,6 +80,13 @@ export default function GoogleMap({ params }) {
         <Marker
           coordinate={destination.region}
           onPress={() => handlePressMarker()}
+        />
+      )}
+      {destination.isGuideStart && (
+        <Polyline
+          coordinates={[...destination.routes]}
+          strokeColor="pink"
+          strokeWidth={6}
         />
       )}
     </MapView>

--- a/src/components/ViewDestination.js
+++ b/src/components/ViewDestination.js
@@ -10,11 +10,21 @@ import {
 
 import BottomSheet from "reanimated-bottom-sheet";
 
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { startGuide } from "../store/slices/destinationSlice";
+import { updateSheetState } from "../store/slices/bottomSheetSlice";
+
+import DirectionsAPI from "../api/DirectionsAPI";
 
 export default function ViewDestination() {
+  const dispatch = useDispatch();
+
+  const currentRegion = useSelector(state => state.user.currentRegion);
+  const currentPlaceName = useSelector(state => state.user.placeName);
   const destination = useSelector(state => state.destination.destination);
-  const isBottomSheetOpen = useSelector(state => state.sheet.isBottomSheetOpen);
+  const isBottomSheetOpen = useSelector(
+    state => state.bottomSheet.isBottomSheetOpen
+  );
 
   const bottomSheefRef = useRef(null);
 
@@ -33,7 +43,7 @@ export default function ViewDestination() {
         )}
         <Text>{destination.placeName}</Text>
         <Text>{destination.distance}</Text>
-        <Pressable style={styles.startBtn}>
+        <Pressable style={styles.startBtn} onPress={startDirectionGuide}>
           <Text style={styles.startText}>시작</Text>
         </Pressable>
       </View>
@@ -46,6 +56,17 @@ export default function ViewDestination() {
     }
 
     bottomSheefRef.current.snapTo(1);
+  };
+
+  const startDirectionGuide = async () => {
+    const { points, routes } = await DirectionsAPI(
+      currentRegion,
+      currentPlaceName,
+      destination
+    );
+
+    dispatch(startGuide({ points, routes }));
+    dispatch(updateSheetState());
   };
 
   return (

--- a/src/screens/SearchLocation/index.js
+++ b/src/screens/SearchLocation/index.js
@@ -6,14 +6,13 @@ import {
   TextInput,
   Pressable,
   FlatList,
-  Dimensions,
 } from "react-native";
 
 import Ionicons from "react-native-vector-icons/Ionicons";
 
 import { useSelector, useDispatch } from "react-redux";
 import { updateDestination } from "../../store/slices/destinationSlice";
-import { updateSheetState } from "../../store/slices/sheetSlice";
+import { updateSheetState } from "../../store/slices/bottomSheetSlice";
 
 import PlaceAutoCompleteAPI from "../../api/PlaceAutoCompleteAPI";
 import PlaceDetailsAPI from "../../api/PlaceDetailsAPI";
@@ -25,12 +24,12 @@ export default function SearchLocationScreen({ navigation }) {
   const [searchResult, setSearchResult] = useState("");
 
   const dispatch = useDispatch();
-  const currentPosition = useSelector(state => state.user.currentPosition);
+  const currentRegion = useSelector(state => state.user.currentRegion);
 
   const handleInputTextChange = async text => {
     setInputText(text);
 
-    const searchResult = await PlaceAutoCompleteAPI(text, currentPosition);
+    const searchResult = await PlaceAutoCompleteAPI(text, currentRegion);
     setSearchResult(searchResult.predictions);
   };
 

--- a/src/store/config/config.js
+++ b/src/store/config/config.js
@@ -1,12 +1,12 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import user from "../slices/userSlice";
 import destination from "../slices/destinationSlice";
-import sheet from "../slices/sheetSlice";
+import bottomSheet from "../slices/bottomSheetSlice";
 
 const rootReducer = combineReducers({
   user,
   destination,
-  sheet,
+  bottomSheet,
 });
 
 const store = configureStore({

--- a/src/store/slices/bottomSheetSlice.js
+++ b/src/store/slices/bottomSheetSlice.js
@@ -4,8 +4,8 @@ const initialState = {
   isBottomSheetOpen: false,
 };
 
-const sheetSlice = createSlice({
-  name: "sheet",
+const bottomSheetSlice = createSlice({
+  name: "bottomSheet",
   initialState,
   reducers: {
     updateSheetState(state) {
@@ -14,6 +14,6 @@ const sheetSlice = createSlice({
   },
 });
 
-export const { updateSheetState } = sheetSlice.actions;
+export const { updateSheetState } = bottomSheetSlice.actions;
 
-export default sheetSlice.reducer;
+export default bottomSheetSlice.reducer;

--- a/src/store/slices/destinationSlice.js
+++ b/src/store/slices/destinationSlice.js
@@ -6,6 +6,9 @@ const initialState = {
     region: {},
     distance: 0,
     photoURL: "",
+    points: [],
+    routes: [],
+    isGuideStart: false,
   },
 };
 
@@ -16,9 +19,16 @@ const destinationSlice = createSlice({
     updateDestination(state, action) {
       state.destination = action.payload;
     },
+    startGuide(state, action) {
+      const { points, routes } = action.payload;
+
+      state.destination.points = points;
+      state.destination.routes = routes;
+      state.destination.isGuideStart = true;
+    },
   },
 });
 
-export const { updateDestination } = destinationSlice.actions;
+export const { updateDestination, startGuide } = destinationSlice.actions;
 
 export default destinationSlice.reducer;

--- a/src/store/slices/userSlice.js
+++ b/src/store/slices/userSlice.js
@@ -2,12 +2,13 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   uid: "",
-  currentPosition: {
+  currentRegion: {
     latitude: 37.497,
     longitude: 127.0254,
     latitudeDelta: 0.015,
     longitudeDelta: 0.0121,
   },
+  placeName: "",
 };
 
 const userSlice = createSlice({
@@ -17,12 +18,15 @@ const userSlice = createSlice({
     addUid(state, action) {
       state.uid = action.payload;
     },
-    updateCurrentPosition(state, action) {
-      state.currentPosition = action.payload;
+    updateCurrentPoint(state, action) {
+      const { currentRegion, placeName } = action.payload;
+
+      state.currentRegion = currentRegion;
+      state.placeName = placeName;
     },
   },
 });
 
-export const { addUid, updateCurrentPosition } = userSlice.actions;
+export const { addUid, updateCurrentPoint } = userSlice.actions;
 
 export default userSlice.reducer;


### PR DESCRIPTION
## 작업사항
1. 길찾기 API를 사용하여 현재 위치에서 도착 장소까지의 이동 경로의 좌표값을 받아오고 배열 객체형태로 전역 상태로 관리합니다.
2. Polyline에 이동 경로의 좌표값을 넣어 지도에 이동 경로에 대한 선이 표시됩니다.
3. Geocode API를 통해 현재 위치에 대한 주소명을 받아 userSlice의 placeName 속성으로 관리합니다.

## 이슈
- 구글의 Direction API를 사용하기로 계획했지만 국내에서는 walking 모드가 제공되지 않고 transit 모드만 제공되어서 도보 경로를 제공하는 티맵 API로 변경하였습니다.
- 티맵 길찾기 API는 요청할 때 출발 장소의 주소명과 도착 장소의 주소명이 파라미터로 필요하기 때문에 Reverse Geocode API를 추가하여 현재 위치에 대한 주소명을 받아와 사용하였습니다.